### PR TITLE
ACMS-1169: Fix issue for page CT create node.

### DIFF
--- a/src/Helpers/Task/Steps/EnableModules.php
+++ b/src/Helpers/Task/Steps/EnableModules.php
@@ -66,6 +66,15 @@ class EnableModules {
         "--yes",
       ], [$args['packages']['admin']]);
       $this->drushCommand->prepare($command)->run();
+
+      // Use admin theme as acquia_claro.
+      $command = array_merge([
+        "config:set",
+        "node.settings",
+        "use_admin_theme",
+        "--yes",
+      ], [TRUE]);
+      $this->drushCommand->prepare($command)->run();
     }
 
     if ($args['type'] == "themes") {


### PR DESCRIPTION
When I setup site using starter kit tools with acquia_cms_demo/acquia_cms_low_code use case, I observed that I am not able to create content of page type.

Currently, I can see two JS issue in browser console.