### PR TITLE
ACMS-1259: Installing site with starterkit low-code have issue.

### DIFF
--- a/src/Cli.php
+++ b/src/Cli.php
@@ -134,25 +134,21 @@ class Cli {
   public function alterModulesAndThemes(array &$starterKit, array $userInputValues) :array {
     $isContentModel = $userInputValues['content_model'] ?? '';
     $isDemoContent = $userInputValues['demo_content'] ?? '';
+    $contentModelModules = [
+      'acquia_cms_article:^1.3.4',
+      'acquia_cms_page:^1.3.3',
+      'acquia_cms_event:^1.3.4',
+    ];
 
     // Set default theme as olivero (if not defined)
     $starterKit['themes']['default'] = $starterKit['themes']['default'] ?? "olivero";
 
     if ($isContentModel == "yes") {
-      $starterKit['modules']['install'] = array_merge(
-        $starterKit['modules']['install'], [
-          'acquia_cms_article:^1.3.4',
-          'acquia_cms_page:^1.3.3',
-          'acquia_cms_event:^1.3.4',
-        ],
-      );
+      $starterKit['modules']['install'] = array_merge($starterKit['modules']['install'], $contentModelModules);
     }
     if ($isDemoContent == "yes") {
-      $starterKit['modules']['install'] = array_merge(
-        $starterKit['modules']['install'], [
-          'acquia_cms_starter:^1.3.0',
-        ],
-      );
+      $demoContentModules = array_merge($contentModelModules, ['acquia_cms_starter:^1.3.0']);
+      $starterKit['modules']['install'] = array_merge($starterKit['modules']['install'], $demoContentModules);
     }
     $starterKit['modules']['install'] = array_unique($starterKit['modules']['install']);
     return $starterKit;


### PR DESCRIPTION
### Description of Issue
Installing site with starterkit low-code enterprise also with demo content, I can see issue on pages like article, people, places & search.

### Steps to Reproduce

- mkdir composer-project && cd composer-project
- composer init, and hit enter to provide default value for each field asked.
- composer config repositories.acquia_cms_starterkit vcs 'git@github.com:acquia/acquia-cms-starterkit.git'
- composer require acquia/acquia-cms-starterkit:dev-develop
- export your site studio keys
- ./vendor/bin/acms acms:install
- Select enterprise as starterkit
- Select demo content

### Expected Result
We should be able to see all pages without any issue including styling.