### PR TITLE
Enable consumer_image_styles on acquia_cms_headless

### DIFF
--- a/acms/acms.yml
+++ b/acms/acms.yml
@@ -49,11 +49,13 @@ starter_kits:
         - acquia_cms_search:^1.3.5
         - acquia_cms_tour:^1.3.0
         - acquia_cms_toolbar:^1.3.3
+        - consumer_image_styles:^4.0.7
       install:
         - acquia_cms_headless_ui
         - acquia_cms_search
         - acquia_cms_tour
         - acquia_cms_toolbar
+        - consumer_image_styles
     themes:
       require:
         - acquia_claro:^1.3.2

--- a/tests/unit/CliTest.php
+++ b/tests/unit/CliTest.php
@@ -133,12 +133,14 @@ class CliTest extends TestCase {
               "acquia_cms_search:^1.3.5",
               "acquia_cms_tour:^1.3.0",
               "acquia_cms_toolbar:^1.3.3",
+              "consumer_image_styles:^4.0.7",
             ],
             "install" => [
               "acquia_cms_headless_ui",
               "acquia_cms_search",
               "acquia_cms_tour",
               "acquia_cms_toolbar",
+              "consumer_image_styles",
             ],
           ],
           "themes" => [


### PR DESCRIPTION
This enableds consumer_image_styles on acquia_cms_headless which is required for https://github.com/acquia/next-acms/issues/37.