### PR TITLE
ACMS-1470: Include Acquia CMS DAM Module.

### DIFF
--- a/.github/workflows/acms.yml
+++ b/.github/workflows/acms.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Install
         run: |
           cd ../orca-build
+          composer config -g github-oauth.github.com ${{ secrets.OAUTH_TOKEN }}
           ./vendor/bin/acms acms:install ${{ matrix.starter-kits }} --no-interaction
       - name: Execute all PHPUnit tests
         run: ./vendor/bin/phpunit

--- a/.github/workflows/acms.yml
+++ b/.github/workflows/acms.yml
@@ -49,7 +49,7 @@ jobs:
           ../orca/bin/ci/after_script.sh
   VERIFY_ACMS_STARTERKIT_ON_DRUPAL_PROJECT:
     if: ${{ github.event_name == 'push' }}
-    name: "Verify ${{ matrix.starter-kits }} with demo-content=${{ matrix.demo-content }}, content-model=${{ matrix.content-model }}, core-version=${{ matrix.core-version }} on acquia/drupal-recommended-project"
+    name: "Verify ${{ matrix.starter-kits }} with demo-content=${{ matrix.demo-content }}, content-model=${{ matrix.content-model }}, dam-integration=${{ matrix.dam-integration }}, core-version=${{ matrix.core-version }} on acquia/drupal-recommended-project"
     runs-on: ubuntu-latest
     env:
       ORCA_SUT_NAME: acquia/acquia-cms-starterkit
@@ -63,6 +63,7 @@ jobs:
       COMPOSER_PROCESS_TIMEOUT: 1800
       demo_content: ${{ matrix.demo-content }}
       content_model: ${{ matrix.content-model }}
+      dam_integration: ${{ matrix.dam-integration }}
       # nextjs_app: ${{ matrix.nextjs-app }}
       CI: TRUE
     strategy:
@@ -71,10 +72,17 @@ jobs:
         starter-kits: ["acquia_cms_enterprise_low_code", "acquia_cms_community", "acquia_cms_headless"]
         demo-content: ["yes", "no"]
         content-model: ["yes", "no"]
+        dam-integration: ["yes", "no"]
         # nextjs-app: ["yes", "no"]
         exclude:
           - demo-content: "yes"
             content-model: "yes"
+          - demo-content: "no"
+            content-model: "no"
+            dam-integration: "yes"
+          - demo-content: "yes"
+            content-model: "no"
+            dam-integration: "no"
           # - starter-kits: ["acquia_cms_enterprise_low_code", "acquia_cms_community"]
           #   nextjs-app: "yes"
           # - starter-kits: ["acquia_cms_headless"]

--- a/acms/acms.yml
+++ b/acms/acms.yml
@@ -85,6 +85,16 @@ questions:
         - no
     default_value: "no"
     skip_on_value: false
+  dam_integration:
+    dependencies:
+      starter_kits: acquia_cms_enterprise_low_code || acquia_cms_headless || acquia_cms_community
+    question: "Would you like to enable the Acquia DAM modules (configuration will need to be done manually later after site installation) ?"
+    allowed_values:
+      options:
+        - yes
+        - no
+    skip_on_value: false
+    default_value: "no"
   nextjs_app:
     dependencies:
       starter_kits: acquia_cms_headless

--- a/src/Cli.php
+++ b/src/Cli.php
@@ -134,6 +134,7 @@ class Cli {
   public function alterModulesAndThemes(array &$starterKit, array $userInputValues) :array {
     $isContentModel = $userInputValues['content_model'] ?? '';
     $isDemoContent = $userInputValues['demo_content'] ?? '';
+    $isDamIntegration = $userInputValues['dam_integration'] ?? '';
     $contentModelModules = [
       'acquia_cms_article',
       'acquia_cms_page',
@@ -151,6 +152,10 @@ class Cli {
       $demoContentModules = array_merge($contentModelModules, ['acquia_cms_starter']);
       $starterKit['modules']['require'] = array_merge($starterKit['modules']['require'], $demoContentModules);
       $starterKit['modules']['install'] = array_merge($starterKit['modules']['install'], $demoContentModules);
+    }
+    if ($isDamIntegration == "yes") {
+      $starterKit['modules']['require'] = array_merge($starterKit['modules']['require'], ['acquia_cms_dam']);
+      $starterKit['modules']['install'] = array_merge($starterKit['modules']['install'], ['acquia_cms_dam']);
     }
     $starterKit['modules']['require'] = array_unique($starterKit['modules']['require']);
     $starterKit['modules']['install'] = array_unique($starterKit['modules']['install']);

--- a/src/Helpers/Task/Steps/DownloadModules.php
+++ b/src/Helpers/Task/Steps/DownloadModules.php
@@ -76,6 +76,14 @@ class DownloadModules {
     }
     $packages = array_merge($args['modules']['require'], $args['themes']['require']);
     $packages = JsonParser::downloadPackages($packages);
+    if (in_array('drupal/acquia_cms_dam', $packages)) {
+      $this->composerCommand->prepare([
+        "config",
+        "repositories.acquia_cms_dam",
+        "--json",
+        '{ "type": "vcs", "name": "drupal/acquia_cms_dam", "url": "https://github.com/acquia/acquia_cms_dam.git" }',
+      ])->run();
+    }
     $inputArgument = array_merge(["require", "-W"], $packages);
     return $this->composerCommand->prepare($inputArgument)->run();
   }

--- a/src/Helpers/Task/Steps/DownloadModules.php
+++ b/src/Helpers/Task/Steps/DownloadModules.php
@@ -81,7 +81,7 @@ class DownloadModules {
         "config",
         "repositories.acquia_cms_dam",
         "--json",
-        '{ "type": "vcs", "name": "drupal/acquia_cms_dam", "url": "https://github.com/acquia/acquia_cms_dam.git" }',
+        '{ "type": "vcs", "name": "drupal/acquia_cms_dam", "url": "git@github.com:acquia/acquia_cms_dam.git" }',
       ])->run();
     }
     $inputArgument = array_merge(["require", "-W"], $packages);

--- a/tests/unit/CliTest.php
+++ b/tests/unit/CliTest.php
@@ -153,6 +153,7 @@ class CliTest extends TestCase {
       "questions" => array_merge (
         self::getContentModel(),
         self::getDemoContent(),
+        self::getDamIntegration(),
         self::getNextjsApp(),
         self::getNextjsAppSiteUrl(),
         self::getNextjsAppSiteName(),
@@ -205,6 +206,28 @@ class CliTest extends TestCase {
         ],
         'default_value' => 'no',
         'skip_on_value' => FALSE,
+      ],
+    ];
+  }
+
+  /**
+   * Returns the test data for dam_integration Question.
+   *
+   * @return array[]
+   *   Returns an array of question.
+   */
+  public static function getDamIntegration(): array {
+    return [
+      'dam_integration' => [
+        'dependencies' => [
+          'starter_kits' => 'acquia_cms_enterprise_low_code || acquia_cms_headless || acquia_cms_community',
+        ],
+        'question' => "Would you like to enable the Acquia DAM modules (configuration will need to be done manually later after site installation) ?",
+        'allowed_values' => [
+          'options' => ['yes', 'no'],
+        ],
+        'skip_on_value' => FALSE,
+        'default_value' => 'no',
       ],
     ];
   }

--- a/tests/unit/Helpers/InstallerQuestionsTest.php
+++ b/tests/unit/Helpers/InstallerQuestionsTest.php
@@ -211,6 +211,7 @@ class InstallerQuestionsTest extends TestCase {
         array_merge(
           CliTest::getDemoContent(),
           CliTest::getContentModel(),
+          CliTest::getDamIntegration(),
           CliTest::getGmapsKey(),
           CliTest::getSiteStudioApiKey(),
           CliTest::getSiteStudioOrgKey(),
@@ -221,6 +222,7 @@ class InstallerQuestionsTest extends TestCase {
         array_merge(
           CliTest::getDemoContent(),
           CliTest::getContentModel(),
+          CliTest::getDamIntegration(),
           CliTest::getGmapsKey(),
         ),
       ],
@@ -229,6 +231,7 @@ class InstallerQuestionsTest extends TestCase {
         array_merge(
           CliTest::getDemoContent(),
           CliTest::getContentModel(),
+          CliTest::getDamIntegration(),
           CliTest::getGmapsKey(),
           CliTest::getNextjsApp(),
           CliTest::getNextjsAppSiteUrl(),


### PR DESCRIPTION
Fixes #ACMS-1470
Include acquia_cms_dam module.

**Testing Steps:**
- Checkout this branch
- Execute `bin/acms acms:install` command
- Verify that "Would you like to enable the Acquia DAM modules (configuration will need to be done manually later after site installation) ?" question appears on screen
- Select yes to above question
- Verify acquia_cms_dam module downloaded and installed