### PR TITLE
ACMS-1843: update Acquia recommended client latest release tag to master.

### DIFF
--- a/src/Http/Client/Github/AcquiaRecommendedClient.php
+++ b/src/Http/Client/Github/AcquiaRecommendedClient.php
@@ -15,7 +15,7 @@ class AcquiaRecommendedClient extends GithubBase {
    *
    * @var string
    */
-  protected $latestReleaseTag = "drupal10";
+  protected $latestReleaseTag = "master";
 
   /**
    * Returns the GitHub repo name.


### PR DESCRIPTION
Drupal10 branch has been removed from [DRP](https://github.com/acquia/drupal-recommended-project) project, causing installation error, so update latest release tag to master.
<img width="878" alt="Screenshot 2023-06-27 at 2 46 34 PM" src="https://github.com/acquia/acquia-cms-starterkit/assets/19570710/60bbe896-862c-4944-a432-5a5202292a25">
