### PR TITLE
ACMS-1905: Track Acquia CMS starterkits in telemetry data.

### DIFF
--- a/acms/build.yml
+++ b/acms/build.yml
@@ -11,7 +11,7 @@ sites:
       - acquia_cms_toolbar
       - acquia_cms_tour
       - acquia_cms_video
-    starter_kit: acquia_cms_existing_site
+    starter_kit: acquia_cms_enterprise_low_code
     themes:
       admin: acquia_claro
       default: cohesion_theme

--- a/src/Helpers/Task/InstallTask.php
+++ b/src/Helpers/Task/InstallTask.php
@@ -298,12 +298,6 @@ class InstallTask {
       ]);
     }
 
-    // Add user selected starter-kit to state.
-    $command = array_merge([
-      "state:set",
-      "acquia_cms.starter_kit",
-    ], [$this->bundle]);
-    $this->drushCommand->prepare($command)->run();
     // Add user selected starter-kit to config.
     $command = array_merge([
       "config:set",

--- a/src/Helpers/Task/InstallTask.php
+++ b/src/Helpers/Task/InstallTask.php
@@ -225,12 +225,6 @@ class InstallTask {
 
     $this->siteInstall->execute($siteInstallArgs);
 
-    // Add user selected starter-kit to state.
-    $command = array_merge([
-      "state:set",
-      "acquia_cms.starter_kit",
-    ], [$this->bundle]);
-    $this->drushCommand->prepare($command)->run();
     $bundleModules = $this->buildInformation['modules'] ?? [];
     // Get User password from shared factory or from option argument.
     $password = $siteInstallArgs['account-pass'] ?? SharedFactory::getData('password');
@@ -303,6 +297,21 @@ class InstallTask {
         '--env-file' => $isNextjsAppEnvFile,
       ]);
     }
+
+    // Add user selected starter-kit to state.
+    $command = array_merge([
+      "state:set",
+      "acquia_cms.starter_kit",
+    ], [$this->bundle]);
+    $this->drushCommand->prepare($command)->run();
+    // Add user selected starter-kit to config.
+    $command = array_merge([
+      "config:set",
+      "acquia_cms_common.settings",
+      "starter_kit_name",
+      "--yes",
+    ], [$this->bundle]);
+    $this->drushCommand->prepare($command)->run();
   }
 
   /**


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1905

**Proposed changes**
Track Acquia CMS Starterkits in telemetry data.

**Alternatives considered**
NA

**Testing steps**
Follow from ticket.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
