### PR TITLE
ACMS-1979: To make starterkit script commands work with starterkit validation.

### DIFF
--- a/src/Cli.php
+++ b/src/Cli.php
@@ -246,6 +246,7 @@ class Cli {
     }
     $starterKit['modules']['require'] = array_unique($starterKit['modules']['require']);
     $starterKit['modules']['install'] = array_values(array_unique($starterKit['modules']['install']));
+
     return $starterKit;
   }
 

--- a/src/Cli.php
+++ b/src/Cli.php
@@ -2,8 +2,8 @@
 
 namespace AcquiaCMS\Cli;
 
-use AcquiaCMS\Cli\Validation\StarterKitValidation;
 use AcquiaCMS\Cli\Helpers\Traits\UserInputTrait;
+use AcquiaCMS\Cli\Validation\StarterKitValidation;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -148,11 +148,15 @@ class Cli {
       }
     }
 
-    // Send each starterkit for validation.
-    $schema = $this->getAcquiaCmsFile($this->projectDirectory . '/acms/schema.json');
-    $this->starterKitValidation->validateStarterKits($schema, $starterkits);
+    $starterKits = $starterKitData ?? $defaultStarterkits;
 
-    return $starterKitData ?? $defaultStarterkits;
+    // Send each starterkit for validation.
+    if ($type === 'starter_kits') {
+      $schema = $this->getAcquiaCmsFile($this->projectDirectory . '/acms/schema.json');
+      $this->starterKitValidation->validateStarterKits($schema, $starterKits);
+    }
+
+    return $starterKits;
   }
 
   /**

--- a/src/Helpers/Task/BuildTask.php
+++ b/src/Helpers/Task/BuildTask.php
@@ -32,7 +32,7 @@ class BuildTask {
    *
    * @var mixed
    */
-  protected $starterKits;
+  protected $starterKitsData;
 
   /**
    * Holds the Validate Drupal step object.
@@ -130,6 +130,7 @@ class BuildTask {
     $this->bundle = $bundle;
     $this->input = $input;
     $this->output = $output;
+    $this->starterKitsData = $this->acquiaCmsCli->getStarterKitsData('starter_kits')[$this->bundle];
   }
 
   /**
@@ -153,7 +154,7 @@ class BuildTask {
     }
     $this->print("Downloading all packages/modules/themes required by the starter-kit:", 'headline');
     $this->buildModulesAndThemes($args);
-    $this->downloadModules->execute($this->acquiaCmsCli->getStarterKitsData('starter_kits')[$this->bundle]);
+    $this->downloadModules->execute($this->starterKitsData);
   }
 
   /**
@@ -163,7 +164,7 @@ class BuildTask {
    *   An array of params argument to pass.
    */
   protected function buildModulesAndThemes(array $args): void {
-    $this->acquiaCmsCli->alterModulesAndThemes($this->acquiaCmsCli->getStarterKitsData('starter_kits')[$this->bundle], $args['keys']);
+    $this->acquiaCmsCli->alterModulesAndThemes($this->starterKitsData, $args['keys']);
   }
 
   /**
@@ -177,9 +178,8 @@ class BuildTask {
   public function createBuild(array $args, string $site): void {
     $build_path = $this->projectDir . '/acms';
     $this->buildModulesAndThemes($args);
-    $this->starterKits = $this->acquiaCmsCli->getStarterKitsData('starter_kits');
-    $installed_modules = $this->starterKits[$this->bundle]['modules']['install'];
-    $installed_themes = $this->starterKits[$this->bundle]['themes'];
+    $installed_modules = $this->starterKitsData['modules']['install'];
+    $installed_themes = $this->starterKitsData['themes'];
 
     // Build array structure for build.yml.
     $build_content = [

--- a/src/Helpers/Task/BuildTask.php
+++ b/src/Helpers/Task/BuildTask.php
@@ -153,7 +153,7 @@ class BuildTask {
     }
     $this->print("Downloading all packages/modules/themes required by the starter-kit:", 'headline');
     $this->buildModulesAndThemes($args);
-    $this->downloadModules->execute($this->acquiaCmsCli->getStarterKitsData()[$this->bundle]);
+    $this->downloadModules->execute($this->acquiaCmsCli->getStarterKitsData('starter_kits')[$this->bundle]);
   }
 
   /**
@@ -162,8 +162,8 @@ class BuildTask {
    * @param array $args
    *   An array of params argument to pass.
    */
-  protected function buildModulesAndThemes(array $args) :void {
-    $this->acquiaCmsCli->alterModulesAndThemes($this->acquiaCmsCli->getStarterKitsData()[$this->bundle], $args['keys']);
+  protected function buildModulesAndThemes(array $args): void {
+    $this->acquiaCmsCli->alterModulesAndThemes($this->acquiaCmsCli->getStarterKitsData('starter_kits')[$this->bundle], $args['keys']);
   }
 
   /**
@@ -174,10 +174,10 @@ class BuildTask {
    * @param string $site
    *   The site uri.
    */
-  public function createBuild(array $args, string $site) :void {
+  public function createBuild(array $args, string $site): void {
     $build_path = $this->projectDir . '/acms';
     $this->buildModulesAndThemes($args);
-    $this->starterKits = $this->acquiaCmsCli->getStarterKitsData();
+    $this->starterKits = $this->acquiaCmsCli->getStarterKitsData('starter_kits');
     $installed_modules = $this->starterKits[$this->bundle]['modules']['install'];
     $installed_themes = $this->starterKits[$this->bundle]['themes'];
 
@@ -223,7 +223,7 @@ class BuildTask {
    * @param string $type
    *   Type of styling the message.
    */
-  protected function print(string $message, string $type) :void {
+  protected function print(string $message, string $type): void {
     $this->output->writeln($this->style($message, $type));
   }
 

--- a/src/Helpers/Task/InstallTask.php
+++ b/src/Helpers/Task/InstallTask.php
@@ -216,7 +216,7 @@ class InstallTask {
   public function run(array $args): void {
     $this->print("Installing Site:", 'headline');
     $starterkitName = 'Existing Site';
-    $this->starterKits = $this->acquiaCmsCli->getStarterKitsData();
+    $this->starterKits = $this->acquiaCmsCli->getStarterKitsData('starter_kits');
     if (isset($this->starterKits[$this->bundle])) {
       $starterkitName = $this->starterKits[$this->bundle]['name'];
     }
@@ -363,7 +363,7 @@ class InstallTask {
     $starter_kit_name = 'Existing Site';
     $this->buildInformation = $this->acquiaCmsCli->getBuildInformtaion($site_uri);
     if ($this->buildInformation['starter_kit'] != 'acquia_cms_existing_site') {
-      $starter_kit_name = $this->acquiaCmsCli->getStarterKitsData()[$this->buildInformation['starter_kit']]['name'];
+      $starter_kit_name = $this->acquiaCmsCli->getStarterKitsData('starter_kits')[$this->buildInformation['starter_kit']]['name'];
     }
     return [
       $this->buildInformation['starter_kit'],

--- a/src/Helpers/Task/InstallTask.php
+++ b/src/Helpers/Task/InstallTask.php
@@ -35,7 +35,7 @@ class InstallTask {
    *
    * @var mixed
    */
-  protected $starterKits;
+  protected $starterKitsData;
 
   /**
    * Holds the Validate Drupal step object.
@@ -205,6 +205,7 @@ class InstallTask {
     $this->input = $input;
     $this->output = $output;
     $this->siteUri = $site_uri;
+    $this->starterKitsData = $this->acquiaCmsCli->getStarterKitsData('starter_kits')[$this->bundle];
   }
 
   /**
@@ -216,9 +217,8 @@ class InstallTask {
   public function run(array $args): void {
     $this->print("Installing Site:", 'headline');
     $starterkitName = 'Existing Site';
-    $this->starterKits = $this->acquiaCmsCli->getStarterKitsData('starter_kits');
-    if (isset($this->starterKits[$this->bundle])) {
-      $starterkitName = $this->starterKits[$this->bundle]['name'];
+    if (isset($this->starterKitsData)) {
+      $starterkitName = $this->starterKitsData['name'];
     }
     $options = array_filter($this->input->getOptions());
     $installArgs = [];
@@ -360,14 +360,15 @@ class InstallTask {
    *   Returns the starterkit name, machine name.
    */
   public function getStarterKitName(string $site_uri): array {
-    $starter_kit_name = 'Existing Site';
+    $starterKitName = 'Existing Site';
     $this->buildInformation = $this->acquiaCmsCli->getBuildInformtaion($site_uri);
     if ($this->buildInformation['starter_kit'] != 'acquia_cms_existing_site') {
-      $starter_kit_name = $this->acquiaCmsCli->getStarterKitsData('starter_kits')[$this->buildInformation['starter_kit']]['name'];
+      $starterKitName = $this->acquiaCmsCli->getStarterKitsData('starter_kits')[$this->buildInformation['starter_kit']]['name'];
     }
+
     return [
       $this->buildInformation['starter_kit'],
-      $starter_kit_name,
+      $starterKitName,
     ];
   }
 

--- a/src/Helpers/Task/Steps/DownloadModules.php
+++ b/src/Helpers/Task/Steps/DownloadModules.php
@@ -44,7 +44,7 @@ class DownloadModules {
    * @param array $args
    *   An array of params argument to pass.
    */
-  public function execute(array $args = []) :int {
+  public function execute(array $args = []): int {
     $composerContents = $this->acquiaCmsCli->getRootComposer();
     $composerContents = json_decode($composerContents);
     $composerContentsExtra = $composerContents->{'extra'};
@@ -124,6 +124,7 @@ class DownloadModules {
     $packages = JsonParser::downloadPackages($packages);
     $inputArgument = array_merge(["require", "-W"], $packages);
     $this->composerCommand->prepare($inputArgument)->run();
+
     return $this->composerCommand->prepare(["update", "--lock"])->run();
   }
 

--- a/tests/unit/CliTest.php
+++ b/tests/unit/CliTest.php
@@ -4,6 +4,7 @@ namespace tests;
 
 use AcquiaCMS\Cli\Cli;
 use AcquiaCMS\Cli\Helpers\Traits\UserInputTrait;
+use AcquiaCMS\Cli\Validation\StarterKitValidation;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Console\Output\OutputInterface;


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes ACMS-1979

**Proposed changes**
To work along with starterkit validation

**Testing steps**
Perform all the scenarios as per ACMS-1900 and 1925
