### PR TITLE
ACMS-3361: Support SS v7.4: Enable the sitestudio_claro module by default for the customers.

### DIFF
--- a/acms/acms.yml
+++ b/acms/acms.yml
@@ -17,6 +17,7 @@ starter_kits:
         - shield
       install:
         - acquia_cms_site_studio
+        - sitestudio_claro
         - acquia_cms_page
         - acquia_cms_search
         - acquia_cms_tour

--- a/acms/build.yml
+++ b/acms/build.yml
@@ -2,6 +2,7 @@ sites:
   default:
     modules:
       - acquia_cms_site_studio
+      - sitestudio_claro
       - acquia_cms_article
       - acquia_cms_document
       - acquia_cms_event

--- a/src/Helpers/Task/InstallTask.php
+++ b/src/Helpers/Task/InstallTask.php
@@ -229,6 +229,14 @@ class InstallTask {
     // Get User password from shared factory or from option argument.
     $password = $siteInstallArgs['account-pass'] ?? SharedFactory::getData('password');
     $this->print("User name: admin, User password: $password", 'info');
+
+    // Enable themes.
+    $this->print("Enabling themes for the starter-kit:", 'headline');
+    $this->enableThemes->execute([
+      'themes' => $this->buildInformation['themes'],
+      'starter_kit' => $this->bundle,
+    ]);
+
     $this->print("Enabling modules for the starter-kit:", 'headline');
     $isDemoContent = FALSE;
     $modulesList = JsonParser::installPackages($bundleModules);
@@ -242,13 +250,6 @@ class InstallTask {
     $this->enableModules->execute([
       'modules' => $modulesList,
       'keys' => $args['keys'],
-    ]);
-
-    // Enable themes.
-    $this->print("Enabling themes for the starter-kit:", 'headline');
-    $this->enableThemes->execute([
-      'themes' => $this->buildInformation['themes'],
-      'starter_kit' => $this->bundle,
     ]);
 
     // Toggle modules based on environments.

--- a/tests/unit/CliTest.php
+++ b/tests/unit/CliTest.php
@@ -116,6 +116,7 @@ class CliTest extends TestCase {
             ],
             "install" => [
               "acquia_cms_site_studio",
+              "sitestudio_claro",
               "acquia_cms_page",
               "acquia_cms_search",
               "acquia_cms_tour",


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #ACMS-3361

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
