### PR TITLE
Integration of Canvas with Drupal Community Starter Kit.

### DIFF
--- a/.github/workflows/acms.yml
+++ b/.github/workflows/acms.yml
@@ -57,7 +57,7 @@ jobs:
           ../orca/bin/ci/after_script.sh
   VERIFY_ACMS_STARTERKIT_ON_DRUPAL_PROJECT:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    name: "Verify ${{ matrix.starter-kits }} with demo-content=${{ matrix.demo-content }}, content-model=${{ matrix.content-model }}, dam-integration=${{ matrix.dam-integration }}, gdpr-integration=${{ matrix.gdpr-integration }}, core-version=${{ matrix.core-version }} on acquia/drupal-recommended-project"
+    name: "Verify ${{ matrix.starter-kits }} with demo-content=${{ matrix.demo-content }}, content-model=${{ matrix.content-model }}, dam-integration=${{ matrix.dam-integration }}, gdpr-integration=${{ matrix.gdpr-integration }}, canvas-integration=${{ matrix.canvas-integration }}, core-version=${{ matrix.core-version }} on acquia/drupal-recommended-project"
     runs-on: ubuntu-latest
     env:
       demo_content: ${{ matrix.demo-content }}
@@ -69,6 +69,7 @@ jobs:
       SITESTUDIO_API_KEY: ${{ secrets.SITESTUDIO_API_KEY }}
       SITESTUDIO_ORG_KEY: ${{ secrets.SITESTUDIO_ORG_KEY }}
       gdpr_integration: ${{ matrix.gdpr-integration }}
+      canvas_integration: ${{ matrix.canvas-integration }}
       CI: TRUE
     strategy:
       matrix:
@@ -78,6 +79,7 @@ jobs:
         content-model: ["yes", "no"]
         dam-integration: ["yes", "no"]
         gdpr-integration: ["yes", "no"]
+        canvas-integration: ["yes", "no"]
         exclude:
           - demo-content: "yes"
             content-model: "yes"
@@ -87,12 +89,15 @@ jobs:
           - demo-content: "yes"
             content-model: "no"
             dam-integration: "no"
+            canvas-integration: "no"
           - demo-content: "no"
             content-model: "no"
             gdpr-integration: "yes"
+            canvas-integration: "yes"
           - demo-content: "yes"
             content-model: "no"
             gdpr-integration: "no"
+            canvas-integration: "no"
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2

--- a/acms/acms.yml
+++ b/acms/acms.yml
@@ -128,6 +128,16 @@ questions:
           - no
       default_value: "no"
       skip_on_value: false
+    canvas_integration:
+      dependencies:
+        starter_kits: acquia_cms_community
+      question: "Would you like to enable the Acquia Canvas modules?"
+      allowed_values:
+        options:
+          - yes
+          - no
+      skip_on_value: false
+      default_value: "no"
   install:
     nextjs_app:
       dependencies:

--- a/src/Cli.php
+++ b/src/Cli.php
@@ -191,6 +191,7 @@ class Cli {
     $isDemoContent = $userInputValues['demo_content'] ?? '';
     $isDamIntegration = $userInputValues['dam_integration'] ?? '';
     $isGdprIntegration = $userInputValues['gdpr_integration'] ?? '';
+    $isCanvasIntegration = $userInputValues['canvas_integration'] ?? '';
     $contentModelModules = [
       'acquia_cms_article',
       'acquia_cms_page',
@@ -215,6 +216,11 @@ class Cli {
     }
     if ($isGdprIntegration == "yes") {
       $gdprModules = ['gdpr', 'eu_cookie_compliance', 'gdpr_fields'];
+      $starterKit['modules']['require'] = array_merge($starterKit['modules']['require'], $gdprModules);
+      $starterKit['modules']['install'] = array_merge($starterKit['modules']['install'], $gdprModules);
+    }
+    if ($isCanvasIntegration == "yes") {
+      $gdprModules = ['experience_builder'];
       $starterKit['modules']['require'] = array_merge($starterKit['modules']['require'], $gdprModules);
       $starterKit['modules']['install'] = array_merge($starterKit['modules']['install'], $gdprModules);
     }

--- a/src/Cli.php
+++ b/src/Cli.php
@@ -220,9 +220,9 @@ class Cli {
       $starterKit['modules']['install'] = array_merge($starterKit['modules']['install'], $gdprModules);
     }
     if ($isCanvasIntegration == "yes") {
-      $gdprModules = ['experience_builder'];
-      $starterKit['modules']['require'] = array_merge($starterKit['modules']['require'], $gdprModules);
-      $starterKit['modules']['install'] = array_merge($starterKit['modules']['install'], $gdprModules);
+      $canvasModules = ['canvas'];
+      $starterKit['modules']['require'] = array_merge($starterKit['modules']['require'], $canvasModules);
+      $starterKit['modules']['install'] = array_merge($starterKit['modules']['install'], $canvasModules);
     }
     $starterKit['modules']['require'] = array_unique($starterKit['modules']['require']);
     $starterKit['modules']['install'] = array_values(array_unique($starterKit['modules']['install']));


### PR DESCRIPTION
This pull request introduces support for enabling Acquia Canvas modules as part of the starter kit configuration and workflow. The changes add a new `canvas_integration` option to the configuration, update the workflow matrix to test this integration, and ensure the necessary modules are installed when selected.

**Configuration and Workflow Enhancements:**

* Added a new `canvas_integration` question to `acms/acms.yml`, allowing users to opt-in for Acquia Canvas modules when using the `acquia_cms_community` starter kit.
* Updated the GitHub Actions workflow (`.github/workflows/acms.yml`) to include `canvas-integration` in the job name, environment variables, matrix strategy, and exclusion rules, ensuring all relevant combinations are tested. [[1]](diffhunk://#diff-ab950cee88a3e7ec09914fd1df3f73814be9d101e26941ccbfe03e1de3cecec3L60-R60) [[2]](diffhunk://#diff-ab950cee88a3e7ec09914fd1df3f73814be9d101e26941ccbfe03e1de3cecec3R72) [[3]](diffhunk://#diff-ab950cee88a3e7ec09914fd1df3f73814be9d101e26941ccbfe03e1de3cecec3R82) [[4]](diffhunk://#diff-ab950cee88a3e7ec09914fd1df3f73814be9d101e26941ccbfe03e1de3cecec3R92-R100)

**Module Installation Logic:**

* Modified the `alterModulesAndThemes` method in `src/Cli.php` to check for the `canvas_integration` option and install the `experience_builder` module when enabled. [[1]](diffhunk://#diff-2715e1365c87080f44dc9848449f6101a079ed8a60928677f487d52f41ec661eR194) [[2]](diffhunk://#diff-2715e1365c87080f44dc9848449f6101a079ed8a60928677f487d52f41ec661eR222-R226)