### PR TITLE
Upgrade acquia/coding-standards to support version 3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/yaml": "^6.2 || ^7.0"
     },
     "require-dev": {
-        "acquia/coding-standards": "^1.0 || ^2.0",
+        "acquia/coding-standards": "^1.0 || ^2.0 || ^3.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
         "ergebnis/composer-normalize": "~2.15.0",
         "phpro/grumphp-shim": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4b5f93eeaf5487ea33c582ec7b128ac",
+    "content-hash": "9e97d923e9c4396a9784118435c17026",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -6381,10 +6381,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This pull request updates the development dependencies in the `composer.json` file to allow for a newer major version of the `acquia/coding-standards` package.

Dependency version update:

* Expanded the version constraint for `acquia/coding-standards` to include `^3.0`, allowing the use of the latest major release.