### PR TITLE
Fix failing Acquia Drupal Starter Kit CI.

### DIFF
--- a/.github/workflows/acms.yml
+++ b/.github/workflows/acms.yml
@@ -235,7 +235,9 @@ jobs:
           mysql -e 'FLUSH PRIVILEGES;' -uroot -proot
           mysql -e 'SHOW GRANTS FOR "drupal"@"localhost";' -uroot -proot
       - name: Download Composer Dependencies
-        run: composer install
+        run: |
+          composer install
+          composer update -W
       - name: Install
         shell: 'script -q -e -c "bash {0}"'
         run: ./bin/acms acms:install --no-interaction

--- a/.github/workflows/acms.yml
+++ b/.github/workflows/acms.yml
@@ -128,6 +128,8 @@ jobs:
 
           ./vendor/bin/acms acms:install ${{ matrix.starter-kits }} --uri=${{ matrix.starter-kits }} --no-interaction
 
+          if [ $? -ne 0 ]; then exit 1; fi
+
           # Revert back, after above command runs.
           cd - && git checkout .
       - name: Execute all PHPUnit tests

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpro/grumphp-shim": "^1.5 || ^2.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^1.9 || ^2",
-        "phpunit/phpunit": "^9.4 || ^10 || ^11 || ^12"
+        "phpunit/phpunit": "^9.4 || ^10 || ^11"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -37,12 +37,12 @@
     },
     "require-dev": {
         "acquia/coding-standards": "^1.0 || ^2.0 || ^3.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
-        "ergebnis/composer-normalize": "~2.15.0",
-        "phpro/grumphp-shim": "^1.5",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2 || ^1.0",
+        "ergebnis/composer-normalize": "^2.0",
+        "phpro/grumphp-shim": "^1.5 || ^2.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpstan/phpstan": "^1.9",
-        "phpunit/phpunit": "^9.4 || ^10"
+        "phpstan/phpstan": "^1.9 || ^2",
+        "phpunit/phpunit": "^9.4 || ^10 || ^11 || ^12"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9744d5fbf0c2f4e80f59a6c2b3ac1e28",
+    "content-hash": "2c9182264702811311e8ba0870738f91",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e97d923e9c4396a9784118435c17026",
+    "content-hash": "9744d5fbf0c2f4e80f59a6c2b3ac1e28",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",

--- a/src/Helpers/Task/BuildTask.php
+++ b/src/Helpers/Task/BuildTask.php
@@ -201,14 +201,14 @@ class BuildTask {
     if ($this->filesystem->exists($build_path)) {
       $file_name = $build_path . '/build.yml';
       if (!$this->filesystem->exists($file_name)) {
-        $yaml_build_content = Yaml::dump($build_content, 4, 2, 0);
+        $yaml_build_content = Yaml::dump($build_content, 4, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
         $this->filesystem->dumpFile($file_name, $yaml_build_content);
       }
       // Write data to the file.
       if ($this->filesystem->exists($file_name)) {
         $value = Yaml::parseFile($file_name);
         $updated_value['sites'] = array_merge($value['sites'], $build_content['sites']);
-        $yaml_updated_value = Yaml::dump($updated_value, 4, 2, 0);
+        $yaml_updated_value = Yaml::dump($updated_value, 4, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
         $this->filesystem->dumpFile($file_name, $yaml_updated_value);
       }
     }

--- a/src/Helpers/Task/BuildTask.php
+++ b/src/Helpers/Task/BuildTask.php
@@ -201,14 +201,14 @@ class BuildTask {
     if ($this->filesystem->exists($build_path)) {
       $file_name = $build_path . '/build.yml';
       if (!$this->filesystem->exists($file_name)) {
-        $yaml_build_content = Yaml::dump($build_content, 4, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+        $yaml_build_content = Yaml::dump($build_content, 4, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_NULL_AS_TILDE);
         $this->filesystem->dumpFile($file_name, $yaml_build_content);
       }
       // Write data to the file.
       if ($this->filesystem->exists($file_name)) {
         $value = Yaml::parseFile($file_name);
         $updated_value['sites'] = array_merge($value['sites'], $build_content['sites']);
-        $yaml_updated_value = Yaml::dump($updated_value, 4, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+        $yaml_updated_value = Yaml::dump($updated_value, 4, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_NULL_AS_TILDE);
         $this->filesystem->dumpFile($file_name, $yaml_updated_value);
       }
     }

--- a/src/Helpers/Task/BuildTask.php
+++ b/src/Helpers/Task/BuildTask.php
@@ -120,12 +120,12 @@ class BuildTask {
   /**
    * Configures the BuildTask class object.
    *
-   * @poram Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Input\InputInterface $input
    *   A Symfony input interface object.
-   * @poram Symfony\Component\Console\Input\OutputInterface $output
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
    *   A Symfony output interface object.
-   * @poram Symfony\Component\Console\Command\Command $output
-   *   The site:build Symfony console command object.
+   * @param string $bundle
+   *   The bundle name.
    */
   public function configure(InputInterface $input, OutputInterface $output, string $bundle) :void {
     $this->bundle = $bundle;
@@ -201,14 +201,14 @@ class BuildTask {
     if ($this->filesystem->exists($build_path)) {
       $file_name = $build_path . '/build.yml';
       if (!$this->filesystem->exists($file_name)) {
-        $yaml_build_content = Yaml::dump($build_content, 4, 2);
+        $yaml_build_content = Yaml::dump($build_content, 4, 2, 0);
         $this->filesystem->dumpFile($file_name, $yaml_build_content);
       }
       // Write data to the file.
       if ($this->filesystem->exists($file_name)) {
         $value = Yaml::parseFile($file_name);
         $updated_value['sites'] = array_merge($value['sites'], $build_content['sites']);
-        $yaml_updated_value = Yaml::dump($updated_value, 4, 2);
+        $yaml_updated_value = Yaml::dump($updated_value, 4, 2, 0);
         $this->filesystem->dumpFile($file_name, $yaml_updated_value);
       }
     }


### PR DESCRIPTION
This pull request updates dependency versions to support newer releases, improves YAML handling in build tasks, and corrects documentation annotations. The changes enhance compatibility, maintainability, and code clarity.

**Dependency updates:**

* Expanded supported versions for several dev dependencies in `composer.json`, including `phpunit/phpunit`, `phpstan/phpstan`, and others, to allow for newer major releases.

**Build task improvements:**

* Updated YAML dumping in `BuildTask.php` to use flags `Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE` and `Yaml::DUMP_NULL_AS_TILDE`, ensuring more consistent output for empty arrays and null values.

**Documentation fixes:**

* Corrected `@param` annotations in the `configure` method of `BuildTask.php` for improved accuracy and IDE support.

**Workflow enhancements:**

* Modified the Composer install step in `.github/workflows/acms.yml` to run both `composer install` and `composer update -W`, ensuring dependencies are up-to-date during CI.