### PR TITLE
ACMS-000: Add --yes flag to theme:enable command to automatically confirm theme enabling.

### DIFF
--- a/src/Helpers/Task/Steps/EnableThemes.php
+++ b/src/Helpers/Task/Steps/EnableThemes.php
@@ -41,7 +41,7 @@ class EnableThemes {
     ];
 
     // Enable themes.
-    $command = array_merge(["theme:enable"], [implode(",", $packages)]);
+    $command = array_merge(["theme:enable", "--yes"], [implode(",", $packages)]);
     $this->drushCommand->prepare($command)->run();
 
     // Set admin theme.


### PR DESCRIPTION
This pull request makes a small change to the theme enabling step in the `EnableThemes.php` helper. The update ensures that the theme enabling command is run with the `--yes` flag, allowing it to proceed without interactive confirmation.