### PR TITLE
Add '--yes' option to theme enable command.

### DIFF
--- a/src/Helpers/Task/Steps/EnableThemes.php
+++ b/src/Helpers/Task/Steps/EnableThemes.php
@@ -41,7 +41,7 @@ class EnableThemes {
     ];
 
     // Enable themes.
-    $command = array_merge(["theme:enable"], [implode(",", $packages)]);
+    $command = array_merge(["theme:enable", "--yes"], [implode(",", $packages)]);
     $this->drushCommand->prepare($command)->run();
 
     // Set admin theme.


### PR DESCRIPTION
Fixes - [ACMS-5776](https://acquia.atlassian.net/browse/ACMS-5776)

This pull request makes a small update to the theme enabling process in the `EnableThemes.php` helper. The change ensures that themes are enabled without requiring manual confirmation by adding the `--yes` flag to the `theme:enable` command.

* Added the `--yes` flag to the `theme:enable` Drush command to automate confirmation during theme enabling.